### PR TITLE
Default registrationConfiguration to basic

### DIFF
--- a/src/main/java/io/fusionauth/domain/Application.java
+++ b/src/main/java/io/fusionauth/domain/Application.java
@@ -336,7 +336,7 @@ public class Application implements Buildable<Application>, _InternalJSONColumn,
 
     public Requirable mobilePhone = new Requirable();
 
-    public RegistrationType type;
+    public RegistrationType type = RegistrationType.basic;
 
     @Override
     public boolean equals(Object o) {


### PR DESCRIPTION
## Issue
https://github.com/FusionAuth/fusionauth-issues/issues/810

## Bug Description
When creating a new Application, enabling self-service registration, the form shows fields for both types.  This is because on an AddAction, `registrationConfiguration` is null.  

## Solution
Default the type on an Application object to `basic` 