### PR TITLE
[130] Message Templates Domain Objects

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -20,7 +20,7 @@ javaErrorVersion = "2.2.2"
 fusionauthJWTVersion = "3.6.0"
 restifyVersion = "3.4.1"
 
-project(group: "io.fusionauth", name: "fusionauth-java-client", version: "1.21.1", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-java-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/build.savant
+++ b/build.savant
@@ -20,7 +20,7 @@ javaErrorVersion = "2.2.2"
 fusionauthJWTVersion = "3.6.0"
 restifyVersion = "3.4.1"
 
-project(group: "io.fusionauth", name: "fusionauth-java-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-java-client", version: "1.23.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.fusionauth</groupId>
   <artifactId>fusionauth-java-client</artifactId>
-  <version>1.21.1</version>
+  <version>1.22.0</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth Java Client Library</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.fusionauth</groupId>
   <artifactId>fusionauth-java-client</artifactId>
-  <version>1.22.0</version>
+  <version>1.23.0</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth Java Client Library</name>

--- a/src/main/java/io/fusionauth/client/FusionAuthClient.java
+++ b/src/main/java/io/fusionauth/client/FusionAuthClient.java
@@ -79,6 +79,8 @@ import io.fusionauth.domain.api.MessageTemplateResponse;
 import io.fusionauth.domain.api.OAuthConfigurationResponse;
 import io.fusionauth.domain.api.PasswordValidationRulesResponse;
 import io.fusionauth.domain.api.PendingResponse;
+import io.fusionauth.domain.api.PreviewMessageTemplateRequest;
+import io.fusionauth.domain.api.PreviewMessageTemplateResponse;
 import io.fusionauth.domain.api.PreviewRequest;
 import io.fusionauth.domain.api.PreviewResponse;
 import io.fusionauth.domain.api.PublicKeyResponse;
@@ -2529,6 +2531,20 @@ public class FusionAuthClient {
         .uri("/api/message/template")
         .urlSegment(messageTemplateId)
         .get()
+        .go();
+  }
+
+  /**
+   * Creates a preview of the message template provided in the request, normalized to a given locale.
+   *
+   * @param request The request that contains the email template and optionally a locale to render it in.
+   * @return The ClientResponse object.
+   */
+  public ClientResponse<PreviewMessageTemplateResponse, Errors> retrieveMessageTemplatePreview(PreviewMessageTemplateRequest request) {
+    return start(PreviewMessageTemplateResponse.class, Errors.class)
+        .uri("/api/message/template/preview")
+        .bodyHandler(new JSONBodyHandler(request, objectMapper))
+        .post()
         .go();
   }
 

--- a/src/main/java/io/fusionauth/client/FusionAuthClient.java
+++ b/src/main/java/io/fusionauth/client/FusionAuthClient.java
@@ -74,6 +74,8 @@ import io.fusionauth.domain.api.LoginResponse;
 import io.fusionauth.domain.api.MemberDeleteRequest;
 import io.fusionauth.domain.api.MemberRequest;
 import io.fusionauth.domain.api.MemberResponse;
+import io.fusionauth.domain.api.MessageTemplateRequest;
+import io.fusionauth.domain.api.MessageTemplateResponse;
 import io.fusionauth.domain.api.OAuthConfigurationResponse;
 import io.fusionauth.domain.api.PasswordValidationRulesResponse;
 import io.fusionauth.domain.api.PendingResponse;
@@ -521,6 +523,22 @@ public class FusionAuthClient {
   }
 
   /**
+   * Creates an message template. You can optionally specify an Id for the template, if not provided one will be generated.
+   *
+   * @param messageTemplateId (Optional) The Id for the template. If not provided a secure random UUID will be generated.
+   * @param request The request object that contains all of the information used to create the message template.
+   * @return The ClientResponse object.
+   */
+  public ClientResponse<MessageTemplateResponse, Errors> createMessageTemplate(UUID messageTemplateId, MessageTemplateRequest request) {
+    return start(MessageTemplateResponse.class, Errors.class)
+        .uri("/api/message/template")
+        .urlSegment(messageTemplateId)
+        .bodyHandler(new JSONBodyHandler(request, objectMapper))
+        .post()
+        .go();
+  }
+
+  /**
    * Creates a tenant. You can optionally specify an Id for the tenant, if not provided one will be generated.
    *
    * @param tenantId (Optional) The Id for the tenant. If not provided a secure random UUID will be generated.
@@ -882,6 +900,20 @@ public class FusionAuthClient {
     return start(Void.TYPE, Errors.class)
         .uri("/api/lambda")
         .urlSegment(lambdaId)
+        .delete()
+        .go();
+  }
+
+  /**
+   * Deletes the message template for the given Id.
+   *
+   * @param messageTemplateId The Id of the message template to delete.
+   * @return The ClientResponse object.
+   */
+  public ClientResponse<Void, Errors> deleteMessageTemplate(UUID messageTemplateId) {
+    return start(Void.TYPE, Errors.class)
+        .uri("/api/message/template")
+        .urlSegment(messageTemplateId)
         .delete()
         .go();
   }
@@ -1632,6 +1664,22 @@ public class FusionAuthClient {
     return start(LambdaResponse.class, Errors.class)
         .uri("/api/lambda")
         .urlSegment(lambdaId)
+        .bodyHandler(new JSONBodyHandler(request, objectMapper))
+        .patch()
+        .go();
+  }
+
+  /**
+   * Updates, via PATCH, the message template with the given Id.
+   *
+   * @param messageTemplateId The Id of the message template to update.
+   * @param request The request that contains just the new message template information.
+   * @return The ClientResponse object.
+   */
+  public ClientResponse<MessageTemplateResponse, Errors> patchMessageTemplate(UUID messageTemplateId, Map<String, Object> request) {
+    return start(MessageTemplateResponse.class, Errors.class)
+        .uri("/api/message/template")
+        .urlSegment(messageTemplateId)
         .bodyHandler(new JSONBodyHandler(request, objectMapper))
         .patch()
         .go();
@@ -2466,6 +2514,32 @@ public class FusionAuthClient {
         .urlParameter("applicationId", applicationId)
         .urlParameter("start", start)
         .urlParameter("end", end)
+        .get()
+        .go();
+  }
+
+  /**
+   * Retrieves the message template for the given Id. If you don't specify the id, this will return all of the message templates.
+   *
+   * @param messageTemplateId (Optional) The Id of the message template.
+   * @return The ClientResponse object.
+   */
+  public ClientResponse<MessageTemplateResponse, Void> retrieveMessageTemplate(UUID messageTemplateId) {
+    return start(MessageTemplateResponse.class, Void.TYPE)
+        .uri("/api/message/template")
+        .urlSegment(messageTemplateId)
+        .get()
+        .go();
+  }
+
+  /**
+   * Retrieves all of the message templates.
+   *
+   * @return The ClientResponse object.
+   */
+  public ClientResponse<MessageTemplateResponse, Void> retrieveMessageTemplates() {
+    return start(MessageTemplateResponse.class, Void.TYPE)
+        .uri("/api/message/template")
         .get()
         .go();
   }
@@ -3441,6 +3515,22 @@ public class FusionAuthClient {
     return start(LambdaResponse.class, Errors.class)
         .uri("/api/lambda")
         .urlSegment(lambdaId)
+        .bodyHandler(new JSONBodyHandler(request, objectMapper))
+        .put()
+        .go();
+  }
+
+  /**
+   * Updates the message template with the given Id.
+   *
+   * @param messageTemplateId The Id of the message template to update.
+   * @param request The request that contains all of the new message template information.
+   * @return The ClientResponse object.
+   */
+  public ClientResponse<MessageTemplateResponse, Errors> updateMessageTemplate(UUID messageTemplateId, MessageTemplateRequest request) {
+    return start(MessageTemplateResponse.class, Errors.class)
+        .uri("/api/message/template")
+        .urlSegment(messageTemplateId)
         .bodyHandler(new JSONBodyHandler(request, objectMapper))
         .put()
         .go();

--- a/src/main/java/io/fusionauth/domain/api/MessageTemplateRequest.java
+++ b/src/main/java/io/fusionauth/domain/api/MessageTemplateRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package io.fusionauth.domain.api;
+
+import com.inversoft.json.JacksonConstructor;
+import io.fusionauth.domain.message.MessageTemplate;
+
+/**
+ * A Message Template Request to the API
+ *
+ * @author Michael Sleevi
+ */
+public class MessageTemplateRequest {
+
+  public MessageTemplate messageTemplate;
+
+  @JacksonConstructor
+  public MessageTemplateRequest() {
+
+  }
+
+  public MessageTemplateRequest(MessageTemplate messageTemplate) {
+    this.messageTemplate = messageTemplate;
+  }
+}

--- a/src/main/java/io/fusionauth/domain/api/MessageTemplateResponse.java
+++ b/src/main/java/io/fusionauth/domain/api/MessageTemplateResponse.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package io.fusionauth.domain.api;
+
+import java.util.List;
+
+import com.inversoft.json.JacksonConstructor;
+import io.fusionauth.domain.message.MessageTemplate;
+
+public class MessageTemplateResponse {
+
+  public MessageTemplate messageTemplate;
+
+  public List<MessageTemplate> messageTemplates;
+
+  @JacksonConstructor
+  public MessageTemplateResponse() {
+
+  }
+
+  public MessageTemplateResponse(MessageTemplate messageTemplate) {
+    this.messageTemplate = messageTemplate;
+  }
+
+  public MessageTemplateResponse(List<MessageTemplate> messageTemplates) {
+    this.messageTemplates = messageTemplates;
+  }
+}

--- a/src/main/java/io/fusionauth/domain/api/PreviewMessageTemplateRequest.java
+++ b/src/main/java/io/fusionauth/domain/api/PreviewMessageTemplateRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package io.fusionauth.domain.api;
+
+import java.util.Locale;
+
+import com.inversoft.json.JacksonConstructor;
+import io.fusionauth.domain.message.MessageTemplate;
+
+/**
+ * @author Michael Sleevi
+ */
+public class PreviewMessageTemplateRequest {
+  public MessageTemplate messageTemplate;
+
+  public Locale locale;
+
+  @JacksonConstructor
+  public PreviewMessageTemplateRequest() {
+  }
+
+  public PreviewMessageTemplateRequest(MessageTemplate messageTemplate, Locale locale) {
+    this.messageTemplate = messageTemplate;
+    this.locale = locale;
+  }
+}

--- a/src/main/java/io/fusionauth/domain/api/PreviewMessageTemplateResponse.java
+++ b/src/main/java/io/fusionauth/domain/api/PreviewMessageTemplateResponse.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package io.fusionauth.domain.api;
+
+import com.inversoft.error.Errors;
+import com.inversoft.json.JacksonConstructor;
+import io.fusionauth.domain.message.Message;
+
+public class PreviewMessageTemplateResponse {
+  public Message message;
+
+  public Errors errors;
+
+  @JacksonConstructor
+  public PreviewMessageTemplateResponse() {
+  }
+
+  public PreviewMessageTemplateResponse(Message message, Errors errors) {
+    this.message = message;
+    this.errors = errors;
+  }
+}

--- a/src/main/java/io/fusionauth/domain/message/Message.java
+++ b/src/main/java/io/fusionauth/domain/message/Message.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package io.fusionauth.domain.message;
+
+import java.util.Objects;
+
+import com.inversoft.json.JacksonConstructor;
+import com.inversoft.json.ToString;
+import io.fusionauth.domain.Buildable;
+
+/**
+ * An incredible simplified view of a message
+ *
+ * @author Michael Sleevi
+ */
+public class Message implements Buildable<Message> {
+  public String text;
+
+
+  @JacksonConstructor
+  public Message() {
+  }
+
+  public Message(String text) {
+    this.text = text;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Message)) {
+      return false;
+    }
+    Message Message = (Message) o;
+    return Objects.equals(text, Message.text);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(text);
+  }
+
+  @Override
+  public String toString() {
+    return ToString.toString(this);
+  }
+}

--- a/src/main/java/io/fusionauth/domain/message/MessageTemplate.java
+++ b/src/main/java/io/fusionauth/domain/message/MessageTemplate.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2020, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package io.fusionauth.domain.message;
+
+import java.time.ZonedDateTime;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.inversoft.json.JacksonConstructor;
+import com.inversoft.json.ToString;
+import io.fusionauth.domain.Buildable;
+import io.fusionauth.domain.LocalizedStrings;
+import io.fusionauth.domain.util.Normalizer;
+
+/**
+ * Stores an message template used to distribute messages;
+ *
+ * @author Michael Sleevi
+ */
+public class MessageTemplate implements Buildable<MessageTemplate> {
+  public String defaultTemplate;
+
+  public UUID id;
+
+  public ZonedDateTime insertInstant;
+
+  public ZonedDateTime lastUpdateInstant;
+
+  public LocalizedStrings localizedTemplates = new LocalizedStrings();
+
+  public String name;
+
+  @JacksonConstructor
+  public MessageTemplate() {
+
+  }
+
+  public MessageTemplate(String defaultTemplate, UUID id, ZonedDateTime insertInstant, ZonedDateTime lastUpdateInstant,
+                         LocalizedStrings localizedTemplates, String name) {
+    this.defaultTemplate = defaultTemplate;
+    this.id = id;
+    this.insertInstant = insertInstant;
+    this.lastUpdateInstant = lastUpdateInstant;
+    this.localizedTemplates = localizedTemplates;
+    this.name = name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MessageTemplate that = (MessageTemplate) o;
+    return defaultTemplate.equals(that.defaultTemplate) &&
+           id.equals(that.id) &&
+           insertInstant.equals(that.insertInstant) &&
+           lastUpdateInstant.equals(that.lastUpdateInstant) &&
+           Objects.equals(localizedTemplates, that.localizedTemplates) &&
+           name.equals(that.name);
+  }
+
+  @JsonIgnore
+  public Set<Locale> getLocalizations() {
+    return new HashSet<>(localizedTemplates.keySet());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(defaultTemplate, id, insertInstant, lastUpdateInstant, localizedTemplates, name);
+  }
+
+  public void normalize() {
+    defaultTemplate = Normalizer.trim(defaultTemplate);
+    name = Normalizer.trim(name);
+
+
+    if (localizedTemplates != null) {
+      localizedTemplates.normalize();
+    }
+  }
+
+  public String toString() {
+    return ToString.toString(this);
+  }
+}


### PR DESCRIPTION
Related Issues
----

* [130](https://github.com/FusionAuth/fusionauth-internal-issues/issues/130)

Background
-----

This PR incorporates the Domain Object changes for the support of enhanced MFA functionality.

Implementation Details
-----

* Changes to the Java Client as defined by the Client Builder changeset.
  * PR: https://github.com/FusionAuth/fusionauth-client-builder/pull/25
* New Message Domain object
* New MessageTemplate Domain object
* New MessageTemplateRequest & Response objects
* New PreviewMessageTemplateRequest & Response objects