### PR TITLE
Return tokenExpirationInstant in a login response or any API response…

### DIFF
--- a/src/main/java/io/fusionauth/domain/api/LoginResponse.java
+++ b/src/main/java/io/fusionauth/domain/api/LoginResponse.java
@@ -15,6 +15,7 @@
  */
 package io.fusionauth.domain.api;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -51,6 +52,8 @@ public class LoginResponse implements Buildable<LoginResponse> {
   public Set<AuthenticationThreats> threatsDetected;
 
   public String token;
+
+  public ZonedDateTime tokenExpirationInstant;
 
   public String twoFactorId;
 

--- a/src/main/java/io/fusionauth/domain/api/UserResponse.java
+++ b/src/main/java/io/fusionauth/domain/api/UserResponse.java
@@ -15,6 +15,7 @@
  */
 package io.fusionauth.domain.api;
 
+import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.UUID;
 
@@ -32,6 +33,8 @@ public class UserResponse {
   public Map<UUID, String> registrationVerificationIds;
 
   public String token;
+
+  public ZonedDateTime tokenExpirationInstant;
 
   public User user;
 

--- a/src/main/java/io/fusionauth/domain/api/user/RegistrationResponse.java
+++ b/src/main/java/io/fusionauth/domain/api/user/RegistrationResponse.java
@@ -15,6 +15,8 @@
  */
 package io.fusionauth.domain.api.user;
 
+import java.time.ZonedDateTime;
+
 import com.inversoft.json.JacksonConstructor;
 import io.fusionauth.domain.User;
 import io.fusionauth.domain.UserRegistration;
@@ -32,6 +34,8 @@ public class RegistrationResponse {
   public String registrationVerificationId;
 
   public String token;
+
+  public ZonedDateTime tokenExpirationInstant;
 
   public User user;
 


### PR DESCRIPTION
… containing a JWT. This value is equivalent to the jwt.exp claim, and correlates to the OAuth2 Token repsonse expires_in value.