### PR TITLE
Add userId to verifyEmailAddress Request

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -25,7 +25,7 @@ javaErrorVersion = "2.2.3"
 restifyVersion = "3.9.1"
 testngVersion = "7.3.0"
 
-project(group: "io.fusionauth", name: "fusionauth-java-client", version: "1.36.1", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-java-client", version: "1.36.5", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       cache()

--- a/src/main/java/io/fusionauth/client/FusionAuthClient.java
+++ b/src/main/java/io/fusionauth/client/FusionAuthClient.java
@@ -4982,7 +4982,7 @@ public class FusionAuthClient {
   }
 
   /**
-   * Manually confirms a user's email address. 
+   * Administratively verify a user's email address. Use this method to bypass email verification for the user.
    * 
    * The request body will contain the userId to be verified. This manual verification method requires an API key.
    *

--- a/src/main/java/io/fusionauth/client/FusionAuthClient.java
+++ b/src/main/java/io/fusionauth/client/FusionAuthClient.java
@@ -4984,7 +4984,7 @@ public class FusionAuthClient {
   /**
    * Administratively verify a user's email address. Use this method to bypass email verification for the user.
    * 
-   * The request body will contain the userId to be verified. This manual verification method requires an API key.
+   * The request body will contain the userId to be verified. An API key is required when sending the userId in the request body.
    *
    * @param request The request that contains the userId to verify.
    * @return The ClientResponse object.

--- a/src/main/java/io/fusionauth/client/FusionAuthClient.java
+++ b/src/main/java/io/fusionauth/client/FusionAuthClient.java
@@ -4969,16 +4969,28 @@ public class FusionAuthClient {
    * the tenant is configured to gate a user until their email address is verified, this procedures requires two values instead of one. 
    * The verificationId is a high entropy value and the one-time use code is a low entropy value that is easily entered in a user interactive form. The 
    * two values together are able to confirm a user's email address and mark the user's email address as verified.
-   * 
-   * Requests made with an API key can instead provide a userId in the request body to override email verification for the user.
    *
    * @param request The request that contains the verificationId and optional one-time use code paired with the verificationId.
-   *     
-   *     API key-authenticated requests can instead provide a userId to override the email verification status for the user.
    * @return The ClientResponse object.
    */
   public ClientResponse<Void, Errors> verifyEmailAddress(VerifyEmailRequest request) {
     return startAnonymous(Void.TYPE, Errors.class)
+        .uri("/api/user/verify-email")
+        .bodyHandler(new JSONBodyHandler(request, objectMapper))
+        .post()
+        .go();
+  }
+
+  /**
+   * Manually confirms a user's email address. 
+   * 
+   * The request body will contain the userId to be verified. This manual verification method requires an API key.
+   *
+   * @param request The request that contains the userId to verify.
+   * @return The ClientResponse object.
+   */
+  public ClientResponse<Void, Errors> verifyEmailAddressByUserId(VerifyEmailRequest request) {
+    return start(Void.TYPE, Errors.class)
         .uri("/api/user/verify-email")
         .bodyHandler(new JSONBodyHandler(request, objectMapper))
         .post()

--- a/src/main/java/io/fusionauth/client/FusionAuthClient.java
+++ b/src/main/java/io/fusionauth/client/FusionAuthClient.java
@@ -4969,8 +4969,12 @@ public class FusionAuthClient {
    * the tenant is configured to gate a user until their email address is verified, this procedures requires two values instead of one. 
    * The verificationId is a high entropy value and the one-time use code is a low entropy value that is easily entered in a user interactive form. The 
    * two values together are able to confirm a user's email address and mark the user's email address as verified.
+   * 
+   * Requests made with an API key can instead provide a userId in the request body to override email verification for the user.
    *
    * @param request The request that contains the verificationId and optional one-time use code paired with the verificationId.
+   *     
+   *     API key-authenticated requests can instead provide a userId to override the email verification status for the user.
    * @return The ClientResponse object.
    */
   public ClientResponse<Void, Errors> verifyEmailAddress(VerifyEmailRequest request) {

--- a/src/main/java/io/fusionauth/domain/api/user/VerifyEmailRequest.java
+++ b/src/main/java/io/fusionauth/domain/api/user/VerifyEmailRequest.java
@@ -15,6 +15,8 @@
  */
 package io.fusionauth.domain.api.user;
 
+import java.util.UUID;
+
 import com.inversoft.json.JacksonConstructor;
 import io.fusionauth.domain.EventInfo;
 import io.fusionauth.domain.api.BaseEventRequest;
@@ -26,6 +28,8 @@ public class VerifyEmailRequest extends BaseEventRequest {
   public String oneTimeCode;
 
   public String verificationId;
+
+  public UUID userId;
 
   @JacksonConstructor
   public VerifyEmailRequest() {

--- a/src/main/java/io/fusionauth/domain/api/user/VerifyEmailRequest.java
+++ b/src/main/java/io/fusionauth/domain/api/user/VerifyEmailRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, FusionAuth, All Rights Reserved
+ * Copyright (c) 2021-2022, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,9 +27,9 @@ import io.fusionauth.domain.api.BaseEventRequest;
 public class VerifyEmailRequest extends BaseEventRequest {
   public String oneTimeCode;
 
-  public String verificationId;
-
   public UUID userId;
+
+  public String verificationId;
 
   @JacksonConstructor
   public VerifyEmailRequest() {

--- a/src/main/java/io/fusionauth/domain/api/user/VerifyEmailRequest.java
+++ b/src/main/java/io/fusionauth/domain/api/user/VerifyEmailRequest.java
@@ -54,4 +54,8 @@ public class VerifyEmailRequest extends BaseEventRequest {
     super(eventInfo);
     this.verificationId = verificationId;
   }
+
+  public VerifyEmailRequest(UUID userId) {
+    this.userId = userId;
+  }
 }


### PR DESCRIPTION
Add `userId` to `VerifyEmailRequest` and update doc comments

**Issue**
- https://github.com/FusionAuth/fusionauth-issues/issues/1319

**Linked PRs**
- https://github.com/FusionAuth/fusionauth-app/pull/119
- https://github.com/FusionAuth/fusionauth-api/pull/53
- https://github.com/FusionAuth/fusionauth-client-builder/pull/45