### PR TITLE
Include applicationIds in CleanSpeakConfiguration's equals and hashCode implementations

### DIFF
--- a/src/main/java/io/fusionauth/domain/CleanSpeakConfiguration.java
+++ b/src/main/java/io/fusionauth/domain/CleanSpeakConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, FusionAuth, All Rights Reserved
+ * Copyright (c) 2018-2022, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,19 +85,19 @@ public class CleanSpeakConfiguration extends Enableable implements Buildable<Cle
     if (this == o) {
       return true;
     }
-    if (!(o instanceof CleanSpeakConfiguration)) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
       return false;
     }
     CleanSpeakConfiguration that = (CleanSpeakConfiguration) o;
-    return super.equals(o) &&
-           Objects.equals(apiKey, that.apiKey) &&
-           Objects.equals(usernameModeration, that.usernameModeration) &&
-           Objects.equals(url, that.url);
+    return Objects.equals(apiKey, that.apiKey) && Objects.equals(applicationIds, that.applicationIds) && Objects.equals(url, that.url) && Objects.equals(usernameModeration, that.usernameModeration);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), apiKey, usernameModeration, url);
+    return Objects.hash(super.hashCode(), apiKey, applicationIds, url, usernameModeration);
   }
 
   public void normalize() {


### PR DESCRIPTION
**Issue**: 
- https://github.com/FusionAuth/fusionauth-issues/issues/1676

**Summary**: 
The `CleanSpeakConfiguration.equals` implementation was not checking the value of `applicationIds` member variable.

**Solution**:
Regenerate `equals` and `hashCode` implementations for the class.

**Linked PR**:
- https://github.com/FusionAuth/fusionauth-app/pull/120
- https://github.com/FusionAuth/fusionauth-api/pull/54