### PR TITLE
fix bug where displayName was not being used when calling the link API

### DIFF
--- a/src/main/java/io/fusionauth/domain/IdentityProviderLink.java
+++ b/src/main/java/io/fusionauth/domain/IdentityProviderLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, FusionAuth, All Rights Reserved
+ * Copyright (c) 2021-2022, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,13 @@ public class IdentityProviderLink implements Buildable<IdentityProviderLink>, _I
   }
 
   public IdentityProviderLink(UUID identityProviderId, String identityProviderUserId, UUID userId) {
+    this.identityProviderId = identityProviderId;
+    this.identityProviderUserId = identityProviderUserId;
+    this.userId = userId;
+  }
+
+  public IdentityProviderLink(String displayName, UUID identityProviderId, String identityProviderUserId, UUID userId) {
+    this.displayName = displayName;
     this.identityProviderId = identityProviderId;
     this.identityProviderUserId = identityProviderUserId;
     this.userId = userId;


### PR DESCRIPTION
**Issue**: 
--https://github.com/FusionAuth/fusionauth-issues/issues/1728

**Linked PR**:
--https://github.com/FusionAuth/fusionauth-app/pull/127
