### PR TITLE
ENG-2230 Bump restify to pick up a fix for the reported issue in FusionAuth.

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -18,7 +18,7 @@ fusionauthJWTVersion = "5.2.4"
 jacksonVersion = "2.15.4"
 jackson5Version = "3.0.1"
 javaErrorVersion = "2.2.3"
-restifyVersion = "4.2.1"
+restifyVersion = "4.3.0-{integration}"
 testngVersion = "7.5.1"
 
 project(group: "io.fusionauth", name: "fusionauth-java-client", version: "1.58.0", licenses: ["ApacheV2_0"]) {

--- a/build.savant
+++ b/build.savant
@@ -18,7 +18,7 @@ fusionauthJWTVersion = "5.2.4"
 jacksonVersion = "2.15.4"
 jackson5Version = "3.0.1"
 javaErrorVersion = "2.2.3"
-restifyVersion = "4.3.0-{integration}"
+restifyVersion = "4.3.0"
 testngVersion = "7.5.1"
 
 project(group: "io.fusionauth", name: "fusionauth-java-client", version: "1.58.0", licenses: ["ApacheV2_0"]) {

--- a/fusionauth-java-client.iml
+++ b/fusionauth-java-client.iml
@@ -32,11 +32,11 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/inversoft/restify/4.3.0-{integration}/restify-4.3.0-{integration}.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/inversoft/restify/4.3.0/restify-4.3.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/inversoft/restify/4.3.0-{integration}/restify-4.3.0-{integration}-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/inversoft/restify/4.3.0/restify-4.3.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/fusionauth-java-client.iml
+++ b/fusionauth-java-client.iml
@@ -32,11 +32,11 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/inversoft/restify/4.2.1/restify-4.2.1.jar!/" />
+          <root url="jar://$USER_HOME$/.savant/cache/com/inversoft/restify/4.3.0-{integration}/restify-4.3.0-{integration}.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/inversoft/restify/4.2.1/restify-4.2.1-src.jar!/" />
+          <root url="jar://$USER_HOME$/.savant/cache/com/inversoft/restify/4.3.0-{integration}/restify-4.3.0-{integration}-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>com.inversoft</groupId>
       <artifactId>restify</artifactId>
-      <version>4.2.1</version>
+      <version>4.3.0</version>
       <type>jar</type>
       <scope>compile</scope>
       <optional>false</optional>


### PR DESCRIPTION
### Issue:
- https://github.com/FusionAuth/fusionauth-issues/issues/2978
- https://linear.app/fusionauth/issue/ENG-2230/oidc-providers-which-set-cookies-ending-with-a-semicolon-could-be

### Summary
Sync up version of restify with `fusionauth-app` see related PR. 

### Linked PRs
- https://github.com/fusionauth-eng/fusionauth-app/pull/898
- https://github.com/inversoft/restify/pull/14
